### PR TITLE
add password_confirmation field to settings so that user can update p…

### DIFF
--- a/src/views/Settings/Settings.js
+++ b/src/views/Settings/Settings.js
@@ -157,6 +157,28 @@ class Settings extends Component {
                   </InputWrapper>
                 )}
               </Field>
+              <Field name="password_confirmation">
+                {({ input, meta }) => (
+                  <InputWrapper>
+                    <Input
+                      {...input}
+                      type="password"
+                      placeholder="new password confirmation"
+                      autoCorrect="off"
+                      autoCapitalize="off"
+                      spellcheck="false"
+                      autoComplete="off"
+                    />
+                    <Label>
+                      Leave blank to not change{" "}
+                      {(meta.error || meta.submitError) &&
+                        meta.touched && (
+                          <span>{meta.error || meta.submitError}</span>
+                        )}
+                    </Label>
+                  </InputWrapper>
+                )}
+              </Field>
 
               {submitError && <div className="error">{submitError}</div>}
 


### PR DESCRIPTION
this beautiful piece of code adds password confirmation, like this:

![screen looks like this](https://d.pr/i/oXxpug+)

which is needed if you want to change your password... we need `password` and `password_confirmation` data fields.

As you can see, wasn't sure how to style it so I just copy/paste'd password field 😅