### PR TITLE
fix feed that had pending voice memos which broke ui

### DIFF
--- a/src/views/Activity/Activity.js
+++ b/src/views/Activity/Activity.js
@@ -203,24 +203,14 @@ export default class Activity extends Component {
                     {/* It’s this annoying bag of bones again. */}
                     {/* Here’s some news for ya... */}
                     {/* Some people wanted to use Screenhole as their online diary, so here’s a chomment you left on your own grab. */}
-                    {note.cross_ref && !note.cross_ref.pending ? (
-                      <Memo
-                        message={note.meta.summary}
-                        username={note.actor.username}
-                        gravatar={note.actor.gravatar_hash}
-                        variant={note.variant}
-                        audio={note.cross_ref.media_public_url}
-                        hideUsername={true}
-                      />
-                    ) : (
-                      <Memo
-                        message={note.meta.summary}
-                        username={note.actor.username}
-                        gravatar={note.actor.gravatar_hash}
-                        variant={note.variant}
-                        hideUsername={true}
-                      />
-                    )}
+                    <Memo
+                      message={note.meta.summary}
+                      username={note.actor.username}
+                      gravatar={note.actor.gravatar_hash}
+                      variant={note.variant}
+                      audio={note.cross_ref && !note.cross_ref.pending ? note.cross_ref.media_public_url : null}
+                      hideUsername={true}
+                    />
                   </ActivityInfo>
                   <ActivityMeta>
                     {note.meta.buttcoin_earned && (


### PR DESCRIPTION
@pugson not sure if this is the correct way to approach this but this is a quick fix... feel free to go on this as you wish 👌

- I made a check for `cross_ref` and `cross_ref.pending` which alternatives which view they get
- basically was tripping up whenever `media_public_url` was null from the `memo`