### PR TITLE
Allow API endpoint to be configured via environment variable

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,7 +1,18 @@
 import { create } from "apisauce";
 
-const apiEndpoint =
-  process.env.NODE_ENV === "production" ? "/api" : "https://api.screenhole.net";
+const calculateApiEndpoint = () => {
+  if (process.env.NODE_ENV === 'production') {
+    return '/api';
+  }
+
+  if (process.env.REACT_APP_API_ENDPOINT) {
+    return process.env.REACT_APP_API_ENDPOINT;
+  }
+
+  return 'https://api.screenhole.net';
+}
+
+const apiEndpoint = calculateApiEndpoint();
 
 const api = create({
   baseURL: apiEndpoint,


### PR DESCRIPTION
Right now, it's difficult to develop against a local version of the
Screenhole API. This adds the ability to set a `API_ENDPOINT`
environment variable to use a use an alternative URL during local
development.