### PR TITLE
Chore: added /beta redirect and beta link to download page

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,3 @@
 /api/*  https://api.screenhole.com/:splat  200
+/beta https://d.pr/f/7tnGP1 301
 /*    /index.html   200

--- a/src/views/Static/Apps.js
+++ b/src/views/Static/Apps.js
@@ -25,6 +25,10 @@ export default class apps extends Component {
               rel="noopener noreferrer"
             >
               Macintosh
+            </a>{" "}
+            /{" "}
+            <a href="/beta" target="_blank" rel="noopener noreferrer">
+              (Macintosh Beta 😅)
             </a>
           </p>
         </section>


### PR DESCRIPTION
- [X] add `/beta` redirect via `public/_redirects`
- [X] easier to change link in future (simply rewrite the file in `public/_redirects`)
- [X] add beta download link to UI