### PR TITLE
Feat: add recording type of grabs #yolo edition

### DIFF
--- a/src/components/Grab/Grab.js
+++ b/src/components/Grab/Grab.js
@@ -25,7 +25,7 @@ class Grab extends Component {
       textMemoField: this.props.variant === "single" ? true : false,
       memos: this.props.memos.reverse(),
       description: this.props.description || null,
-      gtype: this.props.gtype || "image",
+      media_type: this.props.media_type || "image",
     };
 
     this.state.isBlocked = false;
@@ -175,17 +175,10 @@ class Grab extends Component {
   };
 
   render() {
+    const { media_type } = this.state;
     var grabMedia;
 
-    switch (this.state.gtype) {
-      case "image":
-        grabMedia = (
-          <GrabImage
-            src={`${this.props.image};1000x1000,fit.png`}
-            alt={`${this.props.username}’s grab on Screenhole`}
-          />
-        );
-        break;
+    switch (media_type) {
       case "recording":
         grabMedia = (
           <video width="400" controls="controls" preload="metadata">

--- a/src/views/GrabSingle/GrabSingle.js
+++ b/src/views/GrabSingle/GrabSingle.js
@@ -68,7 +68,7 @@ class GrabSingle extends Component {
               variant="single"
               created_at={this.state.grab.created_at}
               description={this.state.grab.description}
-              gtype={this.state.grab.gtype}
+              media_type={this.state.grab.media_type}
             />
           </span>
         ) : (

--- a/src/views/GrabStream/GrabStream.js
+++ b/src/views/GrabStream/GrabStream.js
@@ -72,7 +72,7 @@ class GrabStream extends Component {
           index={index}
           created_at={grab.created_at}
           description={grab.description}
-          gtype={grab.gtype}
+          media_type={grab.media_type}
         />,
       );
     });

--- a/src/views/Static/Apps.js
+++ b/src/views/Static/Apps.js
@@ -9,28 +9,34 @@ export default class apps extends Component {
         <section>
           <h1>Download the apps</h1>
           <p>Use our apps to post grabs to the ’hole.</p>
-          <img class="download" src="/img/apps.png" alt="iPhone App" />
-          <p class="links">
-            <a
-              href="http://appstore.com/screenhole"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              iPhone
-            </a>{" "}
-            /{" "}
-            <a
-              href="https://rink.hockeyapp.net/apps/df7fde32da044e62980cfb683cb7d0b9"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Macintosh
-            </a>{" "}
-            /{" "}
-            <a href="/beta" target="_blank" rel="noopener noreferrer">
-              (Macintosh Beta 😅)
-            </a>
-          </p>
+          <img className="download" src="/img/apps.png" alt="iPhone App" />
+          <ul>
+            <li className="links">
+              <a
+                href="http://appstore.com/screenhole"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                iPhone
+              </a>
+            </li>
+            <li className="links">
+              <a
+                href="https://rink.hockeyapp.net/apps/df7fde32da044e62980cfb683cb7d0b9"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Macintosh
+              </a>
+            </li>
+            <li className="beta-link">
+              Feeling adventurous? Checkout our{" "}
+              <a href="/beta" target="_blank" rel="noopener noreferrer">
+                Beta
+              </a>{" "}
+              for Macintosh.
+            </li>
+          </ul>
         </section>
         <Helmet>
           {/* Drop meta tags in here */}
@@ -114,5 +120,11 @@ const Page = styled.div`
   }
   .links {
     font-size: 200%;
+  }
+  .beta-link {
+    font-size: 100%;
+  }
+  li {
+    margin-bottom: 1rem;
   }
 `;

--- a/src/views/UserStream/UserStream.js
+++ b/src/views/UserStream/UserStream.js
@@ -86,7 +86,7 @@ class UserStream extends Component {
           id={grab.id}
           memos={grab.memos}
           gravatar={grab.user.gravatar_hash}
-          gtype={grab.gtype}
+          media_type={grab.media_type}
           key={i}
         />,
       ),


### PR DESCRIPTION
- add recordings #yolo #mvp edition that looks like this:
![image](https://user-images.githubusercontent.com/6380439/42663221-a11feec4-8602-11e8-9810-74b7ed77bc76.png)
- ref:
https://github.com/jake/screenhole-macos/pull/12
https://github.com/jake/screenhole-api/pull/21