### PR TITLE
Expose created_at on user stream

### DIFF
--- a/src/views/UserStream/UserStream.js
+++ b/src/views/UserStream/UserStream.js
@@ -87,6 +87,7 @@ class UserStream extends Component {
           memos={grab.memos}
           gravatar={grab.user.gravatar_hash}
           media_type={grab.media_type}
+          created_at={grab.created_at}
           key={i}
         />,
       ),


### PR DESCRIPTION
Unless it was intentionally hidden on the profile pages, I've added the timestamp to the grab stream here as I find it pretty useful. 